### PR TITLE
Hotkey Sync fixed

### DIFF
--- a/ValheimPlus/Configurations/BaseConfig.cs
+++ b/ValheimPlus/Configurations/BaseConfig.cs
@@ -1,15 +1,22 @@
 using IniParser.Model;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using UnityEngine;
+using ValheimPlus.GameClasses;
+using ValheimPlus.RPC;
+using YamlDotNet.Core.Tokens;
+using static CharacterDrop;
 
 namespace ValheimPlus.Configurations
 {
     public interface IConfig
     {
-        void LoadIniData(KeyDataCollection data);
+        void LoadIniData(KeyDataCollection data, string section);
     }
 
-    public abstract class BaseConfig<T> : IConfig where T : IConfig, new()
+    public abstract class BaseConfig<T> : IConfig where T : class, IConfig, new()
     {
 
         public string ServerSerializeSection()
@@ -24,9 +31,10 @@ namespace ValheimPlus.Configurations
             }
             return r;
         }
-
-        public bool IsEnabled = false;
-        public virtual bool NeedsServerSync { get; set;} = false;
+        [LoadingOption(LoadingMode.Never)]
+        public bool IsEnabled { get; private set; } = false;
+        [LoadingOption(LoadingMode.Never)]
+        public virtual bool NeedsServerSync { get; set; } = false;
 
         public static IniData iniUpdated = null;
 
@@ -34,72 +42,155 @@ namespace ValheimPlus.Configurations
         {
             var n = new T();
 
-            
+
             Debug.Log($"Loading config section {section}");
             if (data[section] == null || data[section]["enabled"] == null || !data[section].GetBool("enabled"))
             {
                 Debug.Log(" Section not enabled");
                 return n;
             }
-
-            n.LoadIniData(data[section]);
+            var keyData = data[section];
+            n.LoadIniData(keyData, section);
 
             return n;
         }
+        private static Dictionary<Type, DGetDataValue> _getValues = new Dictionary<Type, DGetDataValue>()
+        {
+            {typeof(float), GetFloatValue },
+            {typeof(int), GetIntValue },
+            {typeof(KeyCode), GetKeyCodeValue},
+            {typeof(bool), GetBoolValue }
+        };
 
-        public void LoadIniData(KeyDataCollection data)
+        public void LoadIniData(KeyDataCollection data, string section)
         {
             IsEnabled = true;
-
-            foreach (var prop in typeof(T).GetProperties())
+            var thisConfiguration = GetCurrentConfiguration(section);
+            if (thisConfiguration == null)
             {
-                var keyName = prop.Name;
-                if (new[] { "NeedsServerSync", "IsEnabled" }.Contains(keyName)) continue;
-                // Set first char of keyName to lowercase
-                if (keyName != string.Empty && char.IsUpper(keyName[0]))
+                Debug.Log("Configuration not set.");
+                thisConfiguration = this as T;
+                if (thisConfiguration == null) Debug.Log("Error on setting Configuration");
+            }
+
+            foreach (var property in typeof(T).GetProperties())
+            {
+
+
+                if (IgnoreLoading(property))
                 {
-                    keyName = char.ToLower(keyName[0]) + keyName.Substring(1);
+                    continue;
+                }
+                var currentValue = property.GetValue(thisConfiguration);
+                if (IgnoreKeyCode(property))
+                {
+                    property.SetValue(this, currentValue, null);
+                    continue;
                 }
 
-                if (!data.ContainsKey(keyName)) {
+                var keyName = GetKeyNameFromProperty(property);
+
+                if (!data.ContainsKey(keyName))
+                {
                     Debug.Log($" Key {keyName} not defined, using default value");
                     continue;
                 }
 
-                Debug.Log($" Loading key {keyName}");
-                var existingValue = prop.GetValue(this, null);
+                Debug.Log($"{property.Name} [{keyName}] = {currentValue} ({property.PropertyType})");
 
-                if (prop.PropertyType == typeof(float))
+                if (_getValues.ContainsKey(property.PropertyType))
                 {
-                    prop.SetValue(this, data.GetFloat(keyName, (float)existingValue), null);
-                    continue;
+                    var getValue = _getValues[property.PropertyType];
+                    var value = getValue(data, currentValue, keyName);
+                    Debug.Log($"{keyName} = {currentValue} => {value}");
+                    property.SetValue(this, value, null);
                 }
-
-                if (prop.PropertyType == typeof(int))
-                {
-                    prop.SetValue(this, data.GetInt(keyName, (int)existingValue), null);
-                    continue;
-                }
-
-                if (prop.PropertyType == typeof(bool))
-                {
-                    prop.SetValue(this, data.GetBool(keyName), null);
-                    continue;
-                }
-
-                if (prop.PropertyType == typeof(KeyCode) && !RPC.VPlusConfigSync.isConnecting)
-                {
-                    prop.SetValue(this, data.GetKeyCode(keyName, (KeyCode)existingValue), null);
-                    continue;
-                }
-
-                Debug.LogWarning($" Could not load data of type {prop.PropertyType} for key {keyName}");
+                else Debug.LogWarning($" Could not load data of type {property.PropertyType} for key {keyName}");
             }
         }
 
+        delegate object DGetDataValue(KeyDataCollection data, object currentValue, string keyName);
+
+        private static object GetFloatValue(KeyDataCollection data, object currentValue, string keyName)
+        {
+            return data.GetFloat(keyName, (float)currentValue);
+        }
+        private static object GetBoolValue(KeyDataCollection data, object currentValue, string keyName)
+        {
+            return data.GetBool(keyName);
+        }
+        private static object GetIntValue(KeyDataCollection data, object currentValue, string keyName)
+        {
+            return data.GetInt(keyName, (int)currentValue);
+        }
+        private static object GetKeyCodeValue(KeyDataCollection data, object currentValue, string keyName)
+        {
+            return data.GetKeyCode(keyName, (KeyCode)currentValue);
+        }
+
+        private string GetKeyNameFromProperty(PropertyInfo property)
+        {
+            var keyName = property.Name;
+
+            // Set first char of keyName to lowercase
+            if (keyName != string.Empty && char.IsUpper(keyName[0]))
+            {
+                keyName = char.ToLower(keyName[0]) + keyName.Substring(1);
+            }
+            return keyName;
+        }
+        private bool IgnoreLoading(PropertyInfo property)
+        {
+            var loadingOption = property.GetCustomAttribute<LoadingOption>();
+            var loadingMode = loadingOption?.LoadingMode ?? LoadingMode.Always;
+
+            return (VPlusConfigSync.SyncRemote && loadingMode == LoadingMode.LocalOnly
+                || loadingMode == LoadingMode.Never);
+        }
+        private bool IgnoreKeyCode(PropertyInfo property)
+        {
+            return property.PropertyType == typeof(KeyCode) && VPlusConfigSync.SyncRemote && !ConfigurationExtra.SyncHotkeys;
+        }
+
+        private static object GetCurrentConfiguration(string section)
+        {
+            if (Configuration.Current == null) return null;
+            Debug.Log($"Reading Config '{section}'");
+            var properties = Configuration.Current.GetType().GetProperties();
+            PropertyInfo property = properties.SingleOrDefault(p => p.Name.Equals(section, System.StringComparison.CurrentCultureIgnoreCase));
+            if (property == null)
+            {
+                Debug.LogWarning($"Property '{section}' not found in Configuration");
+                return null;
+            }
+            var thisConfiguration = property.GetValue(Configuration.Current) as T;
+            return thisConfiguration;
+        }
     }
 
-    public abstract class ServerSyncConfig<T>: BaseConfig<T> where T : IConfig, new() {
-        public override bool NeedsServerSync { get; set;} = true;
+    public abstract class ServerSyncConfig<T> : BaseConfig<T> where T : class, IConfig, new()
+    {
+        [LoadingOption(LoadingMode.Never)]
+        public override bool NeedsServerSync { get; set; } = true;
+    }
+
+    public class LoadingOption : Attribute
+    {
+        public LoadingMode LoadingMode { get; }
+        public LoadingOption(LoadingMode loadingMode)
+        {
+            LoadingMode = loadingMode;
+        }
+    }
+    /// <summary>
+    /// Defines, when a property is loaded
+    /// </summary>
+    public enum LoadingMode
+    {
+        Always = 0,
+        RemoteOnly = 1,
+        LocalOnly = 2,
+        Never = 3
     }
 }
+

--- a/ValheimPlus/Configurations/BaseConfig.cs
+++ b/ValheimPlus/Configurations/BaseConfig.cs
@@ -82,7 +82,7 @@ namespace ValheimPlus.Configurations
                     continue;
                 }
                 var currentValue = property.GetValue(thisConfiguration);
-                if (IgnoreKeyCode(property))
+                if (LoadLocalOnly(property))
                 {
                     property.SetValue(this, currentValue, null);
                     continue;
@@ -144,12 +144,14 @@ namespace ValheimPlus.Configurations
             var loadingOption = property.GetCustomAttribute<LoadingOption>();
             var loadingMode = loadingOption?.LoadingMode ?? LoadingMode.Always;
 
-            return (VPlusConfigSync.SyncRemote && loadingMode == LoadingMode.LocalOnly
-                || loadingMode == LoadingMode.Never);
+            return (loadingMode == LoadingMode.Never);
         }
-        private bool IgnoreKeyCode(PropertyInfo property)
+        private bool LoadLocalOnly(PropertyInfo property)
         {
-            return property.PropertyType == typeof(KeyCode) && VPlusConfigSync.SyncRemote && !ConfigurationExtra.SyncHotkeys;
+            var loadingOption = property.GetCustomAttribute<LoadingOption>();
+            var loadingMode = loadingOption?.LoadingMode ?? LoadingMode.Always;
+
+            return VPlusConfigSync.SyncRemote && (property.PropertyType == typeof(KeyCode) && !ConfigurationExtra.SyncHotkeys || loadingMode == LoadingMode.LocalOnly);
         }
 
         private static object GetCurrentConfiguration(string section)

--- a/ValheimPlus/Configurations/BaseConfig.cs
+++ b/ValheimPlus/Configurations/BaseConfig.cs
@@ -58,7 +58,7 @@ namespace ValheimPlus.Configurations
         {
             {typeof(float), GetFloatValue },
             {typeof(int), GetIntValue },
-            {typeof(KeyCode), GetKeyCodeValue},
+            {typeof(KeyCode), GetKeyCodeValue },
             {typeof(bool), GetBoolValue }
         };
 

--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -5,7 +5,6 @@ namespace ValheimPlus.Configurations
     public class Configuration
     {
         public static Configuration Current { get; set; }
-        public static Configuration Settings { get; set; }
         public AdvancedBuildingModeConfiguration AdvancedBuildingMode { get; set; }
         public AdvancedEditingModeConfiguration AdvancedEditingMode { get; set; }
         public BedConfiguration Bed { get; set; }

--- a/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
@@ -1,11 +1,25 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿using System.Security.Policy;
+using UnityEngine;
+
+namespace ValheimPlus.Configurations.Sections
 {
     public class ServerConfiguration : BaseConfig<ServerConfiguration>
     {
         public int maxPlayers { get; internal set; } = 10;
         public bool disableServerPassword { get; internal set; } = false;
         public bool enforceMod { get; internal set; } = true;
+        /// <summary>
+        /// Changes whether the server will force it's config on clients that connect. Only affects servers.
+        /// WE HEAVILY RECOMMEND TO NEVER DISABLE THIS! 
+        /// </summary>
+        [LoadingOption(LoadingMode.RemoteOnly)]
         public bool serverSyncsConfig { get; internal set; } = true;
+        /// <summary>
+        /// If false allows you to keep your own defined hotkeys instead of synchronising the ones declared for the server.
+        /// Sections need to be enabled in your local configuration to load hotkeys.
+        /// This is a client side setting and not affected by server settings.
+        /// </summary>
+        [LoadingOption(LoadingMode.LocalOnly)]
         public bool serverSyncHotkeys { get; internal set; } = true;
     }
 

--- a/ValheimPlus/RPC/VPlusConfigSync.cs
+++ b/ValheimPlus/RPC/VPlusConfigSync.cs
@@ -88,7 +88,7 @@ namespace ValheimPlus.RPC
                     }
                     catch (Exception)
                     {
-                        //ignore
+                        throw;
                     }
                     finally
                     {

--- a/ValheimPlus/RPC/VPlusConfigSync.cs
+++ b/ValheimPlus/RPC/VPlusConfigSync.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using BepInEx;
 using ValheimPlus.Configurations;
@@ -7,8 +8,7 @@ namespace ValheimPlus.RPC
 {
     public class VPlusConfigSync
     {
-
-        static public bool isConnecting = false;
+        public static bool SyncRemote { get; private set; } = false;
         public static void RPC_VPlusConfigSync(long sender, ZPackage configPkg)
         {
             if (ZNet.m_isServer) //Server
@@ -49,8 +49,8 @@ namespace ValheimPlus.RPC
             }
             else //Client
             {
-                if (configPkg != null && 
-                    configPkg.Size() > 0 && 
+                if (configPkg != null &&
+                    configPkg.Size() > 0 &&
                     sender == ZRoutedRpc.instance.GetServerPeerID()) //Validate the message is from the server and not another client.
                 {
                     int numLines = configPkg.ReadInt();
@@ -61,38 +61,38 @@ namespace ValheimPlus.RPC
                         return;
                     }
 
-                    using (MemoryStream memStream = new MemoryStream())
+                    try
                     {
-                        using (StreamWriter tmpWriter = new StreamWriter(memStream))
+                        SyncRemote = true;
+                        using (MemoryStream memStream = new MemoryStream())
                         {
-                            for (int i = 0; i < numLines; i++)
+                            using (StreamWriter tmpWriter = new StreamWriter(memStream))
                             {
-                                string line = configPkg.ReadString();
+                                for (int i = 0; i < numLines; i++)
+                                {
+                                    var line = configPkg.ReadString();
+                                    tmpWriter.WriteLine(line);
+                                }
 
-                                tmpWriter.WriteLine(line);
-                            }
+                                tmpWriter.Flush(); //Flush to memStream
+                                memStream.Position = 0; //Rewind stream
 
-                            tmpWriter.Flush(); //Flush to memStream
-                            memStream.Position = 0; //Rewind stream
-
-                            ValheimPlusPlugin.harmony.UnpatchSelf();
-
-                            // Sync HotKeys when connecting ?
-                            if(Configuration.Current.Server.IsEnabled && !Configuration.Current.Server.serverSyncHotkeys)
-                            {
-                                isConnecting = true;
+                                ValheimPlusPlugin.harmony.UnpatchSelf();
                                 Configuration.Current = ConfigurationExtra.LoadFromIni(memStream);
-                                isConnecting = false;
-                            }
-                            else
-                            {
-                                Configuration.Current = ConfigurationExtra.LoadFromIni(memStream);
-                            }
-                                
-                            ValheimPlusPlugin.harmony.PatchAll();
 
-                            ZLog.Log("Successfully synced VPlus configuration from server.");
+                                ValheimPlusPlugin.harmony.PatchAll();
+
+                                ZLog.Log("Successfully synced VPlus configuration from server.");
+                            }
                         }
+                    }
+                    catch (Exception)
+                    {
+                        //ignore
+                    }
+                    finally
+                    {
+                        SyncRemote = false;
                     }
                 }
             }

--- a/ValheimPlus/UI/VPlusSettings.cs
+++ b/ValheimPlus/UI/VPlusSettings.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using ValheimPlus.Configurations;
+using ValheimPlus.RPC;
 using ValheimPlus.Utility;
 
 namespace ValheimPlus.UI
@@ -113,6 +114,7 @@ namespace ValheimPlus.UI
         {
             if (File.Exists(ConfigurationExtra.ConfigIniPath))
             {
+                Debug.Log("Applying Values");
                 FileIniDataParser parser = new FileIniDataParser();
                 IniData configdata = parser.ReadFile(ConfigurationExtra.ConfigIniPath);
                 foreach (KeyValuePair<string, List<GameObject>> settingSection in settingFamillySettings)
@@ -163,7 +165,7 @@ namespace ValheimPlus.UI
                                         continue;
                                     }
 
-                                    if (prop.PropertyType == typeof(KeyCode) && !RPC.VPlusConfigSync.isConnecting)
+                                    if (prop.PropertyType == typeof(KeyCode) && (!VPlusConfigSync.SyncRemote || Configuration.Current.Server.serverSyncHotkeys))
                                     {
                                         prop.SetValue(settingFamilyProp, Enum.Parse(typeof(KeyCode), newVal), null);
                                         configdata[settingSection.Key][settingEntry.name.Replace("(Clone)", "")] = newVal;
@@ -181,7 +183,7 @@ namespace ValheimPlus.UI
                                 string newVal = keycodeNames[inputDropdown.value];
                                 if (newVal == ((KeyCode)prop.GetValue(settingFamilyProp, null)).ToString())
                                     continue;
-                                if (prop.PropertyType == typeof(KeyCode) && !RPC.VPlusConfigSync.isConnecting)
+                                if (prop.PropertyType == typeof(KeyCode) && (!VPlusConfigSync.SyncRemote || Configuration.Current.Server.serverSyncHotkeys))
                                 {
                                     prop.SetValue(settingFamilyProp, Enum.Parse(typeof(KeyCode), newVal), null);
                                     configdata[settingSection.Key][settingEntry.name.Replace("(Clone)", "")] = newVal;


### PR DESCRIPTION
#801
- fixed hotkey sync: local configured hotkeys are used, if syncHotkeyConfig is disabled
- fixed sync for option syncHotkeyConfig: remote setting will be ignored
- refactoring edited code for better readibility
- removed unused property Settings in Configuration