### PR TITLE
Fixing compile error introduced via v0.215.2

### DIFF
--- a/ValheimPlus/GameClasses/FejdStartup.cs
+++ b/ValheimPlus/GameClasses/FejdStartup.cs
@@ -41,7 +41,7 @@ namespace ValheimPlus.GameClasses
             // version text for bottom right of startup
             __instance.m_versionLabel.fontSize = 14;
             __instance.m_versionLabel.GetComponent<RectTransform>().sizeDelta = new Vector2(600, 30);
-            string gameVersion = Version.CombineVersion(global::Version.m_major, global::Version.m_minor, global::Version.m_patch);
+            string gameVersion = global::Version.CurrentVersion.m_major + "." + global::Version.CurrentVersion.m_minor + "." + global::Version.CurrentVersion.m_patch;
             __instance.m_versionLabel.text = "version " + gameVersion + "\n" + "ValheimPlus " + ValheimPlusPlugin.version + " (Grantapher Temporary)";
 
 


### PR DESCRIPTION
fixed error "MissingFieldException: Field 'Version.m_major' not found" after v0.215.2 update