### PR TITLE
Add option to disable config autoupdates

### DIFF
--- a/ValheimPlus/Configurations/ConfigurationExtra.cs
+++ b/ValheimPlus/Configurations/ConfigurationExtra.cs
@@ -41,17 +41,25 @@ namespace ValheimPlus.Configurations
             {
                 if (File.Exists(ConfigIniPath))
                 {
+                    Configuration.Current = LoadFromIni(ConfigIniPath, verbose: true);
+
                     ValheimPlusPlugin.Logger.LogInfo($"Found config file at: '{ConfigIniPath}'");
                     FileIniDataParser parser = new FileIniDataParser();
                     IniData configdata = parser.ReadFile(ConfigIniPath);
 
                     string compareIni = null;
-                    try
+                    if (!Configuration.Current.ValheimPlus.disableConfigAutoUpdates)
                     {
-                        // get the current versions ini data
-                        compareIni = ValheimPlusPlugin.getCurrentWebIniFile();
+                        try
+                        {
+                            // get the current versions ini data
+                            compareIni = ValheimPlusPlugin.getCurrentWebIniFile();
+                        }
+                        catch (Exception) { }
+                    } else
+                    {
+                        ValheimPlusPlugin.Logger.LogWarning("Auto config file updates have been disabled!");
                     }
-                    catch (Exception) { }
 
                     if (compareIni != null)
                     {
@@ -64,8 +72,6 @@ namespace ValheimPlus.Configurations
                         webConfig.Merge(configdata);
                         parser.WriteFile(ConfigIniPath, webConfig);
                     }
-
-                    Configuration.Current = LoadFromIni(ConfigIniPath, verbose: true);
                 }
                 else
                 {

--- a/ValheimPlus/Configurations/Sections/ValheimPlusConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ValheimPlusConfiguration.cs
@@ -4,5 +4,6 @@
     {
         public bool mainMenuLogo { get; internal set; } = true;
         public bool serverBrowserAdvertisement { get; internal set; } = true;
+        public bool disableConfigAutoUpdates { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/ValheimPlus.cs
+++ b/ValheimPlus/ValheimPlus.cs
@@ -117,6 +117,7 @@ namespace ValheimPlus
             string reply = null;
             try
             {
+                Logger.LogInfo($"Downloading latest config from: '{iniFile}'");
                 reply = client.DownloadString(iniFile);
             }
             catch (Exception e)

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -9,6 +9,9 @@ mainMenuLogo=true
 ; Display the advertisement of our server hosting partner on the server browser menu
 serverBrowserAdvertisement=true
 
+; Disables configuration file auto updates from GitHub, useful if GitHub is blocked on your network.
+disableConfigAutoUpdates=false
+
 [AdvancedBuildingMode]
 
 ; https://docs.unity3d.com/ScriptReference/KeyCode.html <- a list of keycodes


### PR DESCRIPTION
Adds option to disable config auto updates as requested by Ladades on NexusMods. It should help people that have GitHub blocked in their network/firewall, by their country's government or other entity.