### PR TITLE
fix: containers with multiple colliders are found more than once

### DIFF
--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -32,6 +32,10 @@ namespace ValheimPlus
                 try
                 {
                     Container foundContainer = hitCollider.GetComponentInParent<Container>();
+
+                    if (validContainers.Contains(foundContainer))
+                        continue;
+
                     bool hasAccess = foundContainer.CheckAccess(Player.m_localPlayer.GetPlayerID());
                     if (checkWard) hasAccess = hasAccess && PrivateArea.CheckAccess(hitCollider.gameObject.transform.position, 0f, false, true);
                     var piece = foundContainer.GetComponentInParent<Piece>();

--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -33,6 +33,8 @@ namespace ValheimPlus
                 {
                     Container foundContainer = hitCollider.GetComponentInParent<Container>();
 
+                    if (!foundContainer)
+                        continue;
                     if (validContainers.Contains(foundContainer))
                         continue;
 


### PR DESCRIPTION
`GetNearbyChests` iterates over all colliders, without checking if a container was already found. This results in containers with multiple colliders to be put into the list multiple times, e.g. with CraftFromChests the number of items displayed is multiplied.

For example, the issue occurs together with my mod https://valheim.thunderstore.io/package/MSchmoecker/DynamicStoragePiles/ and is fixed with this small patch. Current vanilla containers only have a single collider, although this could change in the future.