### PR TITLE
Update Magic Skills names to the ones used by the game.

### DIFF
--- a/ValheimPlus/Configurations/Sections/ExperienceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ExperienceConfiguration.cs
@@ -10,8 +10,8 @@
 		public float blocking { get; internal set; } = 0;
 		public float axes { get; internal set; } = 0;
 		public float bows { get; internal set; } = 0;
-		public float fireMagic { get; internal set; } = 0;
-		public float frostMagic { get; internal set; } = 0;
+		public float elementalMagic { get; internal set; } = 0;
+		public float bloodMagic { get; internal set; } = 0;
 		public float unarmed { get; internal set; } = 0;
 		public float pickaxes { get; internal set; } = 0;
 		public float woodCutting { get; internal set; } = 0;

--- a/ValheimPlus/GameClasses/Skills.cs
+++ b/ValheimPlus/GameClasses/Skills.cs
@@ -43,11 +43,11 @@ namespace ValheimPlus.GameClasses
 					case SkillType.Bows:
 						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.bows);
 						break;
-					case SkillType.FireMagic:
-						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.fireMagic);
+					case SkillType.ElementalMagic:
+						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.elementalMagic);
 						break;
-					case SkillType.FrostMagic:
-						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.frostMagic);
+					case SkillType.BloodMagic:
+						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.bloodMagic);
 						break;
 					case SkillType.Unarmed:
 						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.unarmed);
@@ -121,8 +121,8 @@ namespace ValheimPlus.GameClasses
 		Blocking,
 		Axes,
 		Bows,
-		FireMagic,
-		FrostMagic,
+		ElementalMagic,
+		BloodMagic,
 		Unarmed,
 		Pickaxes,
 		WoodCutting,

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -182,11 +182,11 @@ axes=0
 ; The modifier value for the experience gained of bows.
 bows=0
 
-; The modifier value for the experience gained of fire magic.
-fireMagic=0
+; The modifier value for the experience gained of elemental magic.
+elementalMagic=0
 
-; The modifier value for the experience gained of frost magic.
-frostMagic=0
+; The modifier value for the experience gained of blood magic.
+bloodMagic=0
 
 ; The modifier value for the experience gained of unarmed.
 unarmed=0


### PR DESCRIPTION
Update Magic Skills names to the ones used by the game. I don't know if Fire and Frost was used in the game before and it got updated at some point, but Fire and Frost wasn't working.

Reported by @narwalrusaurus on Discord.