### PR TITLE
[pbt-fix] Fix mute background music setting

### DIFF
--- a/ValheimPlus/GameClasses/Settings.cs
+++ b/ValheimPlus/GameClasses/Settings.cs
@@ -9,43 +9,54 @@ namespace ValheimPlus.GameClasses
     {
         public static Toggle muteAudioToggle;
 
-        public static void CreateToggle()
+        public static bool CreateToggle()
         {
-            Toggle cmToggle = Settings.instance.m_continousMusic;
-            muteAudioToggle = GameObject.Instantiate(cmToggle, cmToggle.transform.parent, false);
-            muteAudioToggle.name = "MuteGameInBackground";
-            muteAudioToggle.GetComponentInChildren<TMP_Text>().text = "Mute Game in Background";
+            foreach (var iSettingsTab in Settings.instance.SettingsTabs)
+            {
+                if (iSettingsTab.GetType() == typeof(Fishlabs.Valheim.AudioSettings))
+                {
+                    Toggle cmToggle = ((Fishlabs.Valheim.AudioSettings)iSettingsTab).m_continousMusic;
+                    muteAudioToggle = GameObject.Instantiate(cmToggle, cmToggle.transform.parent, false);
+                    muteAudioToggle.name = "MuteGameInBackground";
+                    muteAudioToggle.GetComponentInChildren<TMP_Text>().text = "Mute game in background";
 
-            // scaleFactor is overwritten by GuiScaler::UpdateScale, which is called every frame, but impacted when pressing OK in the settings dialog
-            CanvasScaler canvasScalerComponent = muteAudioToggle.transform.root.GetComponentInChildren<CanvasScaler>();
-            muteAudioToggle.transform.Translate(new Vector2(0, -40 * canvasScalerComponent.scaleFactor));
+                    // scaleFactor is overwritten by GuiScaler::UpdateScale, which is called every frame, but impacted when pressing OK in the settings dialog
+                    CanvasScaler canvasScalerComponent = muteAudioToggle.transform.root.GetComponentInChildren<CanvasScaler>();
+                    muteAudioToggle.transform.Translate(new Vector2(0, -40 * canvasScalerComponent.scaleFactor));
+                    return true;
+                }
+            }
+
+            ValheimPlusPlugin.Logger.LogError("Failed to create MuteGameInBackground toggle");
+            return false;
         }
     }
 
     /// <summary>
     /// Read in saved user preference for audio mute toggle
     /// </summary>
-    [HarmonyPatch(typeof(Settings), "Awake")]
+    [HarmonyPatch(typeof(Settings), nameof(Settings.Awake))]
     public static class Settings_LoadSettings_Patch
     {
         private static void Postfix()
         {
-            if (MuteGameInBackground.muteAudioToggle == null)
-                MuteGameInBackground.CreateToggle();
+           if (MuteGameInBackground.muteAudioToggle == null && !MuteGameInBackground.CreateToggle())
+                return;
 
-            MuteGameInBackground.muteAudioToggle.isOn = (PlayerPrefs.GetInt("MuteGameInBackground", 0) == 1); ;
+           MuteGameInBackground.muteAudioToggle.isOn = (PlayerPrefs.GetInt("MuteGameInBackground", 0) == 1); ;
         }
     }
 
     /// <summary>
     /// Save out user preference for audio mute toggle
     /// </summary>
-    [HarmonyPatch(typeof(Settings), "SaveSettings")]
+    [HarmonyPatch(typeof(Settings), nameof(Settings.SaveTabSettings))]
     public static class Settings_SaveSettings_Patch
     {
         private static void Postfix()
         {
-            PlayerPrefs.SetInt("MuteGameInBackground", MuteGameInBackground.muteAudioToggle.isOn ? 1 : 0);
+            if (MuteGameInBackground.muteAudioToggle != null)
+                PlayerPrefs.SetInt("MuteGameInBackground", MuteGameInBackground.muteAudioToggle.isOn ? 1 : 0);
         }
     }
 }


### PR DESCRIPTION
The way settings are managed have been revamped, making this part of the code throw an error as `Settings.SaveSettings` has been removed.

Related error:
```C#
[Warning:  HarmonyX] AccessTools.DeclaredMethod: Could not find method for type Settings and name SaveSettings and parameters 
[Error  :Valheim Plus] Failed to apply patches.
[Warning:Valheim Plus] This version of Valheim Plus (0.9.11.0) was compiled with a game version of "0.217.29", but this game version is newer at "0.217.36". If you are using the PTB, you likely need to use the non-beta version of the game. Otherwise, the errors seen above likely will require the Valheim Plus mod to be updated. If a game update just came out for Valheim, this may take some time for the mod to be updated. See https://github.com/Grantapher/ValheimPlus/blob/grantapher-development/COMPATIBILITY.md for what game versions are compatible with what mod versions.
ArgumentException: Undefined target method for patch method static void ValheimPlus.GameClasses.Settings_SaveSettings_Patch::Postfix()
  at HarmonyLib.PatchClassProcessor.PatchWithAttributes (System.Reflection.MethodBase& lastOriginal) [0x00047] in <474744d65d8e460fa08cd5fd82b5d65f>:0 
  at HarmonyLib.PatchClassProcessor.Patch () [0x0006a] in <474744d65d8e460fa08cd5fd82b5d65f>:0 
Rethrow as HarmonyException: Patching exception in method null
  at ValheimPlus.ValheimPlusPlugin.PatchAll () [0x001bd] in <0c90af76a6194f2ea65dc8ddc90ec3db>:0 
  at ValheimPlus.ValheimPlusPlugin.Awake () [0x00061] in <0c90af76a6194f2ea65dc8ddc90ec3db>:0 
UnityEngine.GameObject:Internal_AddComponentWithType(GameObject, Type)
UnityEngine.GameObject:AddComponent(Type)
BepInEx.Bootstrap.Chainloader:Start()
UnityEngine.GameObject:.cctor()
Fishlabs.Common.SingletonMonoBehaviour`1:get_Instance()
Fishlabs.PlatformManagerInitializer:OnRuntimeMethodLoad()
```