### PR TITLE
keybind dupe/workbench visual scaling fixes

### DIFF
--- a/ValheimPlus/FreePlacementRotation.cs
+++ b/ValheimPlus/FreePlacementRotation.cs
@@ -9,7 +9,6 @@ using System.Runtime;
 using IniParser;
 using IniParser.Model;
 using System.Globalization;
-using Steamworks;
 using ValheimPlus;
 using UnityEngine.Rendering;
 using ValheimPlus.Configurations;

--- a/ValheimPlus/GameClasses/CraftingStation.cs
+++ b/ValheimPlus/GameClasses/CraftingStation.cs
@@ -20,8 +20,8 @@ namespace ValheimPlus.GameClasses
                     {
                         ___m_rangeBuild = Configuration.Current.Workbench.workbenchRange;
                         ___m_areaMarker.GetComponent<CircleProjector>().m_radius = ___m_rangeBuild;
-                        float scaleIncrease = (Configuration.Current.Workbench.workbenchRange - 20f) / 20f * 100f;
-                        ___m_areaMarker.gameObject.transform.localScale = new Vector3(scaleIncrease / 100, 1f, scaleIncrease / 100);
+                        float scaleIncrease = (Configuration.Current.Workbench.workbenchRange) / 20f;
+                        ___m_areaMarker.gameObject.transform.localScale = new Vector3(scaleIncrease, 1f, scaleIncrease);
 
                         // Apply this change to the child GameObject's EffectArea collision.
                         // Various other systems query this collision instead of the PrivateArea radius for permissions (notably, enemy spawning).

--- a/ValheimPlus/GameClasses/Player.cs
+++ b/ValheimPlus/GameClasses/Player.cs
@@ -700,7 +700,7 @@ namespace ValheimPlus.GameClasses
 
         private static void Postfix(ref Player __instance)
         {
-            if (!__instance.IsPlayer())
+            if (__instance != Player.m_localPlayer)
                 return;
 
             if (!Configuration.Current.GridAlignment.IsEnabled)


### PR DESCRIPTION
player postfix was checking if the player was not a player, instead of checking if the player was the local player, causing the keypress to repeat once for every connected player

workbench radius scaling math had a bunch of unnecessary operations built in which caused the visual radius to disappear entirely if the radius was left at the default of 20m