### PR TITLE
Ability to set precise [Gathering] and [Pickable] values

### DIFF
--- a/ValheimPlus/GameClasses/DropTable.cs
+++ b/ValheimPlus/GameClasses/DropTable.cs
@@ -101,11 +101,11 @@ namespace ValheimPlus.GameClasses
 
         private static void AddModifiedDrops(List<GameObject> dropList, GameObject dropObject, float modifier)
         {
-            for (int i = 0; i < Helper.applyModifierValue(1f, modifier); i++)
+            int amount = Helper.applyModifierValueWithChance(1f, modifier);
+            for (int i = 0; i < amount; i++)
             {
                 dropList.Add(dropObject);
             }
-
         }
     }
 

--- a/ValheimPlus/GameClasses/Pickable.cs
+++ b/ValheimPlus/GameClasses/Pickable.cs
@@ -20,7 +20,7 @@ namespace ValheimPlus.GameClasses
 
             if (_yieldModifierDict.TryGetValue(item.name, out float yieldModifier))
             {
-                return (int)Helper.applyModifierValue(originalAmount, yieldModifier);
+                return Helper.applyModifierValueWithChance(originalAmount, yieldModifier);
             }
 
             return originalAmount;

--- a/ValheimPlus/Utility/Helper.cs
+++ b/ValheimPlus/Utility/Helper.cs
@@ -61,25 +61,29 @@ namespace ValheimPlus
             double result = Math.Truncate(mult * value) / mult;
             return (float)result;
         }
-         
-        public static float applyModifierValue(float targetValue, float value)
-        {
-            
+
+        public static float applyModifierValue(float targetValue, float value) {
             if (value <= -100)
-                value = -100;
+                return 0f;
 
-            float newValue = targetValue;
+            return targetValue + (targetValue / 100.0f * value);
+        }
 
-            if (value >= 0)
-            {
-                newValue = targetValue + ((targetValue / 100) * value);
-            }
-            else
-            {
-                newValue = targetValue - ((targetValue / 100) * (value * -1));
-            }
+        /// <summary>
+        /// Calculate new value with chance mechanics.<br/><br/>
+        /// On <c>targetValue = 1</c> and <c>value = 10</c> function will return "1 + (1 with 10% chance)"
+        /// </summary>
+        /// <param name="targetValue">Value to be modified</param>
+        /// <param name="value">Modification coefficient in percentage</param>
+        /// <returns>New value with chance mechanics</returns>
+        public static int applyModifierValueWithChance(float targetValue, float value) {
+            float realValue = applyModifierValue(targetValue, value);
+            if (realValue == 0f)
+                return 0;
+            int guaranteedValue = (int)Math.Floor(realValue);
 
-            return newValue;
+            // 1 - [0; 1) => (0; 1] -- to prevent additional drop on (realValue - guaranteedValue) being zero
+            return guaranteedValue + ((realValue - guaranteedValue) > (1 - new System.Random().NextDouble()) ? 1 : 0);
         }
 
         public static Texture2D LoadPng(Stream fileStream)


### PR DESCRIPTION
This pull request brings possibility to set precise [Gathering] and [Pickable] values.

For example, if you want to increase all edibles overall drop chance by 10%, you just set "edibles = 10". You even can set more precise values like 37.65612 for some reason since all gathering and pickable properties are float type

Currently "edibles = 10" has no effect and drops items as "edibles = 0"

New function in Helper class can be used in other situations, but personally i didn't find them