### PR TITLE
Platform-independent copy files post build event.

### DIFF
--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -272,15 +272,21 @@
     <EmbeddedResource Include="Assets\Bundles\settings-ui" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)ValheimPlus.dll" "$(VALHEIM_INSTALL)\BepInEx\plugins\ValheimPlus.dll"
-copy "$(TargetDir)ValheimPlus.pdb" "$(VALHEIM_INSTALL)\BepInEx\plugins\ValheimPlus.pdb"
-copy "$(TargetDir)ValheimPlus.dll.config" "$(VALHEIM_INSTALL)\BepInEx\plugins\ValheimPlus.dll.config"
-$(SolutionDir)resources\tools\pdb2mdb.exe "$(TargetPath)"
-copy "$(TargetDir)\ValheimPlus.dll.mdb" "$(VALHEIM_INSTALL)\BepInEx\plugins\ValheimPlus.dll.mdb"</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="CopyFiles" AfterTargets="PostBuildEvent">
+    <PropertyGroup>
+      <Dest>$(VALHEIM_INSTALL)/BepInEx/plugins</Dest>
+    </PropertyGroup>
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(Dest)" />
+    <Copy SourceFiles="$(TargetDir)ValheimPlus.pdb" DestinationFolder="$(Dest)" />
+    <Copy SourceFiles="$(TargetDir)ValheimPlus.dll.config" DestinationFolder="$(Dest)" />
+    <!-- Even with an updated version of pdb2mdb that runs under the Mono runtime, 
+    Mono 5 uses Roslyn compiler which produces portable PDBs only, these don't work with pdb2mdb.
+    There doesn't seem to be a way to generate MDBs on Linux or OSX,
+    so don't attempt to generate MDBs if build platform is not Windows. -->
+    <Exec Condition="$([MSBuild]::IsOSPlatform('Windows'))" Command="&quot;$(SolutionDir)resources\tools\pdb2mdb.exe&quot; &quot;$(TargetPath)&quot;" />
+    <Copy Condition="$([MSBuild]::IsOSPlatform('Windows'))" SourceFiles="$(TargetDir)ValheimPlus.dll.mdb" DestinationFolder="$(Dest)" />
+  </Target>
   <Import Project="..\packages\ILRepack.Lib.MSBuild.Task.2.0.33\build\ILRepack.Lib.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.Lib.MSBuild.Task.2.0.33\build\ILRepack.Lib.MSBuild.Task.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
Hey Grant,

Here's a tweak I've been making to all my .net projects so that they build on Linux.

Builds successfully on Linux and Windows. 

MDBs generated only on Windows.

Kind regards,

Snork