### PR TITLE
Fix dedicated server auto-deposit chest lookup

### DIFF
--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -14,9 +14,26 @@ namespace ValheimPlus
         /// </summary>
         public static List<Container> GetNearbyChests(GameObject target, float range, bool checkWard = true)
         {
-            // Every container is filtered by what the local player may access, so without one there
-            // is nothing to return. Null between worlds and always on a dedicated server.
-            if (!Player.m_localPlayer) return new List<Container>();
+            // On clients, container/ward permissions are checked against the local player.
+            // Dedicated servers never have Player.m_localPlayer, but can own production pieces.
+            // In that case use the creator of the machine/piece as the acting player so
+            // server-owned auto-deposit and auto-fuel can still find permitted containers.
+            Player localPlayer = Player.m_localPlayer;
+            long accessPlayerId;
+            if (localPlayer)
+            {
+                accessPlayerId = localPlayer.GetPlayerID();
+            }
+            else
+            {
+                Piece sourcePiece = target ? target.GetComponentInParent<Piece>() : null;
+                if (!sourcePiece)
+                    return new List<Container>();
+
+                accessPlayerId = sourcePiece.GetCreator();
+                if (accessPlayerId == 0L)
+                    return new List<Container>();
+            }
 
             // item == cart layermask
             // vehicle == cart&ship layermask
@@ -51,8 +68,13 @@ namespace ValheimPlus
                     if (validContainers.Contains(foundContainer))
                         continue;
 
-                    bool hasAccess = foundContainer.CheckAccess(Player.m_localPlayer.GetPlayerID());
-                    if (checkWard) hasAccess = hasAccess && PrivateArea.CheckAccess(hitCollider.gameObject.transform.position, 0f, false, true);
+                    bool hasAccess = foundContainer.CheckAccess(accessPlayerId);
+                    if (checkWard)
+                    {
+                        hasAccess = hasAccess && (localPlayer
+                            ? PrivateArea.CheckAccess(hitCollider.gameObject.transform.position, 0f, false, true)
+                            : CheckWardAccessForPlayer(hitCollider.gameObject.transform.position, 0f, accessPlayerId));
+                    }
                     var piece = foundContainer.GetComponentInParent<Piece>();
                     var isVagon = foundContainer.GetComponentInParent<Vagon>() != null;
                     var isShip = foundContainer.GetComponentInParent<Ship>() != null;
@@ -81,6 +103,23 @@ namespace ValheimPlus
             }
 
             return validContainers;
+        }
+
+        private static bool CheckWardAccessForPlayer(Vector3 position, float radius, long playerId)
+        {
+            // Mirrors PrivateArea.CheckAccess(..., wardCheck: true), but does not depend on
+            // Player.m_localPlayer. Every enabled ward covering the container must permit
+            // the creator of the machine performing the automatic transfer.
+            foreach (PrivateArea area in PrivateArea.m_allAreas)
+            {
+                if (!area || !area.IsEnabled() || !area.IsInside(position, radius))
+                    continue;
+
+                if (!area.IsPermitted(playerId))
+                    return false;
+            }
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes nearby chest lookup for server-owned production pieces on dedicated servers.

`InventoryAssistant.GetNearbyChests()` currently returns an empty list whenever `Player.m_localPlayer` is null. On a dedicated server `Player.m_localPlayer` is normally null, so auto-deposit/auto-fuel paths owned by the server cannot discover any nearby containers.

The fix keeps the existing local-player behaviour on clients. When running headlessly, it uses the source piece creator ID as the acting player for container privacy and ward permission checks.

## Reproduction

Tested on:

- Valheim dedicated server `l-1.0.12`, network version 40
- Valheim Plus `0.10.0.3`
- BepInExPack Valheim `5.4.2350`
- Linux dedicated server

A small test-only probe spawned an initialized chest plus server-owned production pieces with the same creator ID and exercised the real V+ methods while `Player.m_localPlayer == null`.

Official `0.10.0.3`:

```text
localPlayer=NULL
smelterOwner=True
sourceCreator=424242424242
nearbyChests=0
FAIL: dedicated-server GetNearbyChests still returned zero containers
```

With this patch:

```text
localPlayer=NULL
chestRevision=4294967295->4
containerLoad=True
smelterOwner=True
beehiveOwner=True
sourceCreator=424242424242
nearbyChests=1
smelter: ore=CopperOre, slotsBefore=0, slotsAfter=1
beehive: slotsBefore=1, slotsAfter=2, level=0
PASS
```

This directly verified actual smelter and beehive auto-deposit on the dedicated-server ownership path. Other auto-deposit/auto-fuel features use the same shared chest lookup.

## Notes

The early-return behaviour appears to originate from commit `707321c` (`Skip the chest search when there is no local player`). This change avoids removing the permission checks entirely and instead preserves them using the producing piece's creator ID on dedicated servers.
